### PR TITLE
Remove bloomfilter-rb dependency

### DIFF
--- a/highscore.gemspec
+++ b/highscore.gemspec
@@ -32,5 +32,4 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency('whatlanguage', ['>=1.0.0'])
-  s.add_dependency('bloomfilter-rb', ['>=2.1.1'])
 end


### PR DESCRIPTION
Documentation says it is optional furthermore its existence is checked in runtime by [use_bloom_filter private method](https://github.com/rgo/highscore/blob/master/lib/highscore/wordlist.rb#L88)[1]

In our case it allows us to install the gem in a JRuby application because bloomfilter-rb is not compatible with JRuby (C extension)

[1] https://github.com/rgo/highscore/blob/master/lib/highscore/wordlist.rb#L88